### PR TITLE
feat: GitHub Issue Form Template (Task 1)

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_post.yml
+++ b/.github/ISSUE_TEMPLATE/new_post.yml
@@ -1,0 +1,55 @@
+name: Neuer Blog-Post (Vorschlag)
+description: Erstelle ein strukturiertes Issue, um automatisch einen neuen Post zu generieren.
+title: "[Vorschlag]: "
+labels: ["ready-to-publish"]
+body:
+  - type: input
+    id: title
+    attributes:
+      label: Titel des Posts
+      description: Der Titel, der im Blog angezeigt wird.
+      placeholder: "Mein spannendes Projekt"
+    validations:
+      required: true
+  - type: input
+    id: author
+    attributes:
+      label: Autor
+      description: Dein Name (oder die Person, die den Text verfasst hat).
+      placeholder: "Jan Thar"
+    validations:
+      required: true
+  - type: dropdown
+    id: category
+    attributes:
+      label: Kategorie
+      options:
+        - events
+        - projects
+        - news
+    validations:
+      required: true
+  - type: textarea
+    id: excerpt
+    attributes:
+      label: Kurzbeschreibung (Excerpt)
+      description: Dieser Text erscheint in der Listenansicht auf der Startseite.
+      placeholder: "Wir haben am Wochenende..."
+    validations:
+      required: true
+  - type: textarea
+    id: content
+    attributes:
+      label: Haupt-Text (Markdown)
+      description: Der eigentliche Text des Posts. Bilder kannst du hier einfach per Drag & Drop reinziehen!
+      placeholder: "Schreibe hier deinen Text..."
+    validations:
+      required: true
+  - type: input
+    id: hero_image
+    attributes:
+      label: Hero-Bild (Name)
+      description: Der Dateiname des Bildes, das oben im Header angezeigt werden soll (z.B. 'mein_bild.jpg'). Lade das Bild unten in den 'Haupt-Text' hoch, damit wir es finden können.
+      placeholder: "herobild.jpg"
+    validations:
+      required: true


### PR DESCRIPTION
### Beschreibung
Dieses PR fügt das strukturierte Issue-Formular hinzu, um Blog-Posts via Issues zu ermöglichen.

### Testanleitung
Da dies ein GitHub-Feature ist, kann es erst nach dem Merge (oder durch Anschauen in der GitHub-UI des Branches) final getestet werden.
1. Gehe in diesem Repo auf 'Issues' -> 'New Issue'.
2. Dort sollte 'Neuer Blog-Post (Vorschlag)' auswählbar sein.
3. Fülle die Felder testweise aus.