### PR TITLE
fix: Support HTML Image Tags in Issue Parser

### DIFF
--- a/scripts/issue_to_markdown.py
+++ b/scripts/issue_to_markdown.py
@@ -7,7 +7,6 @@ from datetime import datetime
 def parse_issue(body):
     NL = chr(10)
     # Regex to find sections: ### Label\n(Content)
-    # Support both \n and \r\n
     sections = re.findall(f'### (.*?)\r?\n(.*?)(?=\r?\n### |\\Z)', body, re.DOTALL)
     data = {}
     for label, content in sections:
@@ -17,40 +16,49 @@ def parse_issue(body):
 def process_images(content, hero_name_hint):
     # Match Markdown images: ![alt](url)
     markdown_images = re.findall(r'!\[(.*?)\]\((https?://.*?)\)', content)
-    # Match HTML images: <img ... src="url" ... /> or <img src="url" ... />
+    # Match HTML images: <img ... src="url" ... />
     html_images = re.findall(r'<img [^>]*src="(https?://[^"]+)"[^>]*>', content)
     
-    # Standardize image list: (alt, url)
+    # Standardize image list: (alt, url, full_match_string)
     images = []
     for alt, url in markdown_images:
         images.append((alt, url, f"![{alt}]({url})"))
     for url in html_images:
-        images.append(("Image", url, re.search(f'<img [^>]*src="{re.escape(url)}"[^>]*>', content).group(0)))
+        # Find the full <img> tag to replace it later
+        full_tag = re.search(f'<img [^>]*src="{re.escape(url)}"[^>]*>', content).group(0)
+        images.append(("Image", url, full_tag))
     
-    hero_image = hero_name_hint if hero_name_hint else ""
+    hero_image = ""
     processed_content = content
     
     os.makedirs("assets/images/hero", exist_ok=True)
     
     for i, (alt, url, full_match) in enumerate(images):
-        # Extract ID from URL for uniqueness
-        img_id = re.sub(r'[^a-zA-Z0-9]', '', url.split('/')[-1])[:10]
-        
+        # Determine extension
         ext = ".jpg"
         if ".png" in url.lower(): ext = ".png"
         elif ".jpeg" in url.lower(): ext = ".jpeg"
         elif ".svg" in url.lower(): ext = ".svg"
         
-        filename = f"issue_{img_id}{ext}"
-        
-        if i == 0 and not hero_image:
+        # Use hero_name_hint for the first image if provided
+        if i == 0 and hero_name_hint:
+            filename = hero_name_hint
+            # Ensure extension matches if hint doesn't have one
+            if "." not in filename:
+                filename += ext
             hero_image = filename
+        else:
+            img_id = re.sub(r'[^a-zA-Z0-9]', '', url.split('/')[-1])[:10]
+            filename = f"issue_{img_id}{ext}"
+            if i == 0:
+                hero_image = filename
         
         local_path = os.path.join("assets/images/hero", filename)
         
         print(f"Downloading {url} to {local_path}...")
         subprocess.run(["curl", "-L", "-s", "-o", local_path, url])
         
+        # Replace the original tag with the Jekyll div snippet
         img_snippet = f'<div class="img img--fullContainer img--14xLeading" style="background-image: url({{{{ site.baseurl_featured_img }}}}{filename});"></div>'
         processed_content = processed_content.replace(full_match, img_snippet)
 
@@ -70,11 +78,9 @@ def generate_markdown(data):
     date_str = date_now.strftime('%Y-%m-%d %H:%M:%S')
     file_date = date_now.strftime('%Y-%m-%d')
     
-    # Safe filename: replace spaces with - and remove special chars
     safe_title = re.sub(r'[^a-zA-Z0-9\s]', '', title).strip().replace(' ', '-')
     filename = f"_posts/{file_date}-{safe_title}.markdown"
     
-    # Format categories
     categories = category.strip()
     
     frontmatter = f"""---
@@ -105,12 +111,10 @@ if __name__ == "__main__":
         body = sys.stdin.read()
     
     if not body.strip():
-        print("Empty body")
         sys.exit(1)
         
     data = parse_issue(body)
     if not data:
-        print("Could not parse issue body. Check format (### Label).")
         sys.exit(1)
         
     filename, markdown = generate_markdown(data)


### PR DESCRIPTION
Dieses PR erweitert den Bild-Parser, sodass auch HTML img-Tags (wie sie GitHub beim Drag-and-Drop erzeugt) erkannt, heruntergeladen und korrekt in das Blog-Format umgewandelt werden.