### PR TITLE
chore: Enable Future Posts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -45,3 +45,4 @@ defaults:
       type: "posts"
     values:
       layout: "default"
+future: true


### PR DESCRIPTION
Dieser PR fügt  zur  hinzu, damit der gepinnte OpenLabDay-Post (Datum 2099) sichtbar bleibt.